### PR TITLE
Update dead/sales-y link to media queries intro

### DIFF
--- a/Week2/README.md
+++ b/Week2/README.md
@@ -186,7 +186,7 @@ The primary way of making a responsive website is by writing custom CSS code tha
 
 Learn more about media queries here:
 
-- [Introduction to Media Queries](https://varvy.com/mobile/media-queries.html).
+- [Introduction to Media Queries](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Media_queries).
 - [Learn CSS Media Query in 7 Minutes](https://www.youtube.com/watch?v=yU7jJ3NbPdA)
 
 ## Finished?


### PR DESCRIPTION
The previous link is now redirected to a sales-y website telling us about a page speed analytics tool. I replaced it with a link to Mozilla's introduction to media queries.